### PR TITLE
Add more rendering primitives

### DIFF
--- a/examples/monadic/Main.idr
+++ b/examples/monadic/Main.idr
@@ -1,17 +1,43 @@
 module Main
 
 import Data.Fin
+import Data.Vect
 import Graphics.Color
 import Graphics.SDL2.SDL
+import Graphics.SDL2.SDLGFX
 import Graphics.SDL2.SDLTTF
 
 draw : SDLRenderer -> IO ()
 draw r = do sdlSetRenderDrawColor r 255 255 255 255 -- background
             sdlRenderClear r
-            filledRect r 100 100 400 400 252 141 89 255
-            filledTrigon r 600 100 500 400 700 400 252 141 89 255
-            font <- ttfOpenFont "/Library/Fonts/Zapfino.ttf" 70
-            renderTextSolid r font "Draco dormiens nunquam titillandus" black 50 500
+            sdlPixel r 10 10 0 0 0 255
+            strokeHLine r 10 20 20 0 0 0 255
+            strokeVLine r 20 10 20 0 0 0 255
+            strokeRectangle r 10 30 20 40 0 0 0 255
+            filledRectangle r 10 50 20 60 0 0 0 255
+            strokeRoundedRectangle r 10 70 30 90 6 0 0 0 255
+            filledRoundedRectangle r 10 100 30 120 6 0 0 0 255
+            strokeLine   r 30 10 40 60 0 0 0 255
+            strokeAALine r 33 10 43 60 0 0 0 255
+            strokeCircle   r 60 20 10 0 0 0 255
+            filledCircle   r 90 20 10 0 0 0 255
+            strokeAACircle r 120 20 10 0 0 0 255
+            strokeEllipse   r 60 50 10 15 255 0 0 255
+            filledEllipse   r 90 50 10 15 0 255 0 255
+            strokeAAEllipse r 120 50 10 15 0 0 255 255
+            filledPie r 130 20 20 (-45) 45 0 0 0 255
+            strokeArc r 140 20 20 (-45) 45 0 0 0 255
+            strokePie r 140 50 20 (-45) 45 0 0 0 255
+            strokeTrigon   r 40 70 60 70 50 90 0 0 0 255
+            filledTrigon   r 70 70 90 70 80 90 0 0 0 255
+            strokeAATrigon r 100 70 120 70 110 90 0 0 0 255
+            strokePolygon   r [10,20,40,30] [130,150,160,140] 0 0 0 255
+            filledPolygon   r [35,45,65,55] [130,150,160,140] 0 0 0 255
+            strokeAAPolygon r [60,70,90,80] [130,150,160,140] 0 0 0 255
+            strokeBezier r [40, 50, 60, 70] [100, 160, 70, 130] 6 0 0 0 255
+            strokeThickLine r 80 100 180 130 5 0 0 0 255
+            font <- ttfOpenFont "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf" 20
+            renderTextSolid r font "Example text" black 10 165
 
             renderPresent r
             ttfCloseFont font
@@ -26,7 +52,7 @@ handle : SDLRenderer -> Event -> IO ()
 handle r e = draw r
 
 main : IO ()
-main = do (win,renderer) <- startSDL "test" 800 600
+main = do (win,renderer) <- startSDL "test" 200 200
           draw renderer
           eventLoop renderer
           endSDL win renderer

--- a/sdl2.ipkg
+++ b/sdl2.ipkg
@@ -1,7 +1,7 @@
 package sdl2
 
 sourcedir = src
-modules = Graphics.SDL2.SDL, Graphics.SDL2.Config, Graphics.SDL2.SDLTTF, Graphics.Color, Graphics.SDL2.Effect
+modules = Graphics.SDL2.SDL, Graphics.SDL2.SDLGFX, Graphics.SDL2.Config, Graphics.SDL2.SDLTTF, Graphics.Color, Graphics.SDL2.Effect
 opts = "-p effects" 
 
 makefile = MakefileSDLC

--- a/src/Graphics/SDL2/Effect.idr
+++ b/src/Graphics/SDL2/Effect.idr
@@ -1,9 +1,11 @@
 module Graphics.SDL2.Effect
 
 import Data.Fin
+import Data.Vect
 import Effects
 import Graphics.Color
 import public Graphics.SDL2.SDL
+import public Graphics.SDL2.SDLGFX
 import public Graphics.SDL2.SDLTTF
 
 public export
@@ -117,7 +119,7 @@ pixel (RGBA r g b a) (x,y)
 public export
 rectangle : Color -> Int -> Int -> Int -> Int -> { [SDL_ON] } Eff () 
 rectangle (RGBA r g b a) x y w h 
-    = call $ WithContext (\(_,s) => filledRect s x y w h (toInt r) (toInt g) (toInt b) (toInt a))
+    = call $ WithContext (\(_,s) => filledRectangle s x y w h (toInt r) (toInt g) (toInt b) (toInt a))
 
 public export
 ellipse : Color -> Int -> Int -> Int -> Int -> { [SDL_ON] } Eff () 
@@ -127,23 +129,23 @@ ellipse (RGBA r g b a) x y rx ry
 public export
 line : Color -> Int -> Int -> Int -> Int -> { [SDL_ON] } Eff () 
 line (RGBA r g b a) x y ex ey 
-    = call $ WithContext (\(_,s) => drawLine s x y ex ey (toInt r) (toInt g) (toInt b) (toInt a))
+    = call $ WithContext (\(_,s) => strokeLine s x y ex ey (toInt r) (toInt g) (toInt b) (toInt a))
 
 public export
 polygon : Color -> List (Int, Int) -> { [SDL_ON] } Eff () 
 polygon (RGBA r g b a) points 
     = do 
-         let xs = map fst points
-         let ys = map snd points
+         let xs = map fst $ fromList points
+         let ys = map snd $ fromList points
          call $ WithContext (\(_,s) => filledPolygon s xs ys (toInt r) (toInt g) (toInt b) (toInt a))
 
 public export
 bezier : Color -> List (Int, Int) -> Int -> { [SDL_ON] } Eff () 
 bezier (RGBA r g b a) points steps
     = do 
-         let xs = map fst points
-         let ys = map snd points
-         call $ WithContext (\(_,s) => sdlBezier s xs ys steps (toInt r) (toInt g) (toInt b) (toInt a))
+         let xs = map fst $ fromList points
+         let ys = map snd $ fromList points
+         call $ WithContext (\(_,s) => strokeBezier s xs ys steps (toInt r) (toInt g) (toInt b) (toInt a))
 
 public export
 triangle : Color -> (Int, Int) -> (Int, Int) -> (Int, Int) -> { [SDL_ON] } Eff () 

--- a/src/Graphics/SDL2/SDLGFX.idr
+++ b/src/Graphics/SDL2/SDLGFX.idr
@@ -1,0 +1,178 @@
+module SDLGFX
+
+import Data.Vect
+import Graphics.SDL2.SDL
+
+%include C "sdlrun2.h"
+%include C "SDL.h"
+%include C "SDL2_gfxPrimitives.h"
+%include C "SDL_ttf.h"
+%link C "sdlrun2.o"
+%lib C "SDL2_gfx"
+%lib C "SDL2_ttf"
+
+%access export
+
+private 
+newArray : Int -> IO (Ptr)
+newArray len = foreign FFI_C "newArray" (Int -> IO (Ptr)) len
+
+private 
+setValue : Ptr -> Int -> Int -> IO ()
+setValue arr idx val = foreign FFI_C "setValue" (Ptr -> Int -> Int -> IO ()) arr idx val
+
+private 
+packValues : Ptr -> Int -> Vect n Int -> IO ()
+packValues arr i [] = pure ()
+packValues arr i (x :: xs) = 
+  do setValue arr i x
+     packValues arr (i + 1) xs
+
+private 
+packVect : {n:Nat} -> Vect n Int -> IO (Ptr)
+packVect {n} xs = do 
+  let len = toIntNat n
+  arr <- newArray $ len
+  packValues arr 0 xs
+  pure arr
+
+public export
+IntAndColorParams : Nat -> Type
+IntAndColorParams Z = Int -> Int -> Int -> Int -> IO ()
+IntAndColorParams (S n) = Int -> IntAndColorParams n
+
+sdlPixel : SDLRenderer -> IntAndColorParams 2
+sdlPixel (MkRenderer ptr) x y r g b a
+  = foreign FFI_C "pixelRGBA" (Ptr -> IntAndColorParams 2) ptr x y r g b a
+
+strokeHLine : SDLRenderer -> IntAndColorParams 3
+strokeHLine (MkRenderer ptr) x1 x2 y r g b a
+  = foreign FFI_C "hlineRGBA" (Ptr -> IntAndColorParams 3) ptr x1 x2 y r g b a
+
+strokeVLine : SDLRenderer -> IntAndColorParams 3
+strokeVLine (MkRenderer ptr) x y1 y2 r g b a
+  = foreign FFI_C "vlineRGBA" (Ptr -> IntAndColorParams 3) ptr x y1 y2 r g b a
+
+strokeRectangle : SDLRenderer -> IntAndColorParams 4
+strokeRectangle (MkRenderer ptr) x1 y1 x2 y2 r g b a
+  = foreign FFI_C "rectangleRGBA" (Ptr -> IntAndColorParams 4) ptr x1 y1 x2 y2 r g b a
+
+filledRectangle : SDLRenderer -> IntAndColorParams 4
+filledRectangle (MkRenderer ptr) x1 y1 x2 y2 r g b a
+  = foreign FFI_C "boxRGBA" (Ptr -> IntAndColorParams 4) ptr x1 y1 x2 y2 r g b a
+
+strokeRoundedRectangle : SDLRenderer -> IntAndColorParams 5
+strokeRoundedRectangle (MkRenderer ptr) x1 y1 x2 y2 rad r g b a
+  = foreign FFI_C "roundedRectangleRGBA" (Ptr -> IntAndColorParams 5) ptr x1 y1 x2 y2 rad r g b a
+
+filledRoundedRectangle : SDLRenderer -> IntAndColorParams 5
+filledRoundedRectangle (MkRenderer ptr) x1 y1 x2 y2 rad r g b a
+  = foreign FFI_C "roundedBoxRGBA" (Ptr -> IntAndColorParams 5) ptr x1 y1 x2 y2 rad r g b a
+
+strokeLine : SDLRenderer -> IntAndColorParams 4
+strokeLine (MkRenderer ptr) x1 y1 x2 y2 r g b a
+      = foreign FFI_C "lineRGBA"
+           (Ptr -> IntAndColorParams 4) ptr x1 y1 x2 y2 r g b a
+
+strokeAALine : SDLRenderer -> IntAndColorParams 4
+strokeAALine (MkRenderer ptr) x1 y1 x2 y2 r g b a
+      = foreign FFI_C "aalineRGBA"
+           (Ptr -> IntAndColorParams 4) ptr x1 y1 x2 y2 r g b a
+
+strokeCircle : SDLRenderer -> IntAndColorParams 3
+strokeCircle (MkRenderer ptr) x y rad r g b a
+      = foreign FFI_C "circleRGBA"
+           (Ptr -> IntAndColorParams 3) ptr x y rad r g b a
+
+filledCircle : SDLRenderer -> IntAndColorParams 3
+filledCircle (MkRenderer ptr) x y rad r g b a
+      = foreign FFI_C "filledCircleRGBA"
+           (Ptr -> IntAndColorParams 3) ptr x y rad r g b a
+
+strokeAACircle : SDLRenderer -> IntAndColorParams 3
+strokeAACircle (MkRenderer ptr) x y rad r g b a
+      = foreign FFI_C "aacircleRGBA"
+           (Ptr -> IntAndColorParams 3) ptr x y rad r g b a
+
+strokeArc : SDLRenderer -> IntAndColorParams 5
+strokeArc (MkRenderer ptr) x y rad start end r g b a
+      = foreign FFI_C "arcRGBA"
+           (Ptr -> IntAndColorParams 5) ptr x y rad start end r g b a
+
+strokePie : SDLRenderer -> IntAndColorParams 5
+strokePie (MkRenderer ptr) x y rad start end r g b a
+      = foreign FFI_C "pieRGBA"
+           (Ptr -> IntAndColorParams 5) ptr x y rad start end r g b a
+
+filledPie : SDLRenderer -> IntAndColorParams 5
+filledPie (MkRenderer ptr) x y rad start end r g b a
+      = foreign FFI_C "filledPieRGBA"
+           (Ptr -> IntAndColorParams 5) ptr x y rad start end r g b a
+
+strokeEllipse : SDLRenderer -> IntAndColorParams 4
+strokeEllipse (MkRenderer ptr) x y rx ry r g b a
+      = foreign FFI_C "ellipseRGBA"
+           (Ptr -> IntAndColorParams 4) ptr x y rx ry r g b a
+
+filledEllipse : SDLRenderer -> IntAndColorParams 4
+filledEllipse (MkRenderer ptr) x y rx ry r g b a
+      = foreign FFI_C "filledEllipseRGBA"
+           (Ptr -> IntAndColorParams 4) ptr x y rx ry r g b a
+
+strokeAAEllipse : SDLRenderer -> IntAndColorParams 4
+strokeAAEllipse (MkRenderer ptr) x y rx ry r g b a
+      = foreign FFI_C "aaellipseRGBA"
+           (Ptr -> IntAndColorParams 4) ptr x y rx ry r g b a
+
+strokeTrigon : SDLRenderer -> IntAndColorParams 6
+strokeTrigon (MkRenderer ptr) x1 y1 x2 y2 x3 y3 r g b a
+      = foreign FFI_C "trigonRGBA"
+           (Ptr -> IntAndColorParams 6) ptr x1 y1 x2 y2 x3 y3 r g b a
+
+filledTrigon : SDLRenderer -> IntAndColorParams 6
+filledTrigon (MkRenderer ptr) x1 y1 x2 y2 x3 y3 r g b a
+      = foreign FFI_C "filledTrigonRGBA"
+           (Ptr -> IntAndColorParams 6) ptr x1 y1 x2 y2 x3 y3 r g b a
+
+strokeAATrigon : SDLRenderer -> IntAndColorParams 6
+strokeAATrigon (MkRenderer ptr) x1 y1 x2 y2 x3 y3 r g b a
+      = foreign FFI_C "aatrigonRGBA"
+           (Ptr -> IntAndColorParams 6) ptr x1 y1 x2 y2 x3 y3 r g b a
+
+strokePolygon : SDLRenderer -> {n : Nat} -> Vect n Int -> Vect n Int -> IntAndColorParams 0
+strokePolygon (MkRenderer ptr) {n} xs ys r g b a = 
+  do 
+    xarr <- packVect xs
+    yarr <- packVect ys
+    let len = toIntNat n
+    foreign FFI_C "strokePolygon" (Ptr -> Ptr -> Ptr -> Int -> IntAndColorParams 0) ptr xarr yarr len r g b a
+
+filledPolygon : SDLRenderer -> {n : Nat} -> Vect n Int -> Vect n Int -> IntAndColorParams 0
+filledPolygon (MkRenderer ptr) {n} xs ys r g b a = 
+  do 
+    xarr <- packVect xs
+    yarr <- packVect ys
+    let len = toIntNat n
+    foreign FFI_C "filledPolygon" (Ptr -> Ptr -> Ptr -> Int -> IntAndColorParams 0) ptr xarr yarr len r g b a
+
+strokeAAPolygon : SDLRenderer -> {n : Nat} -> Vect n Int -> Vect n Int -> IntAndColorParams 0
+strokeAAPolygon (MkRenderer ptr) {n} xs ys r g b a = 
+  do 
+    xarr <- packVect xs
+    yarr <- packVect ys
+    let len = toIntNat n
+    foreign FFI_C "strokeAAPolygon" (Ptr -> Ptr -> Ptr -> Int -> IntAndColorParams 0) ptr xarr yarr len r g b a
+
+strokeBezier : SDLRenderer -> {n : Nat} -> Vect n Int -> Vect n Int -> IntAndColorParams 1
+strokeBezier (MkRenderer ptr) {n} xs ys steps r g b a =
+  do 
+    xarr <- packVect xs
+    yarr <- packVect ys
+    let len = toIntNat n
+    foreign FFI_C "bezier" (Ptr -> Ptr -> Ptr -> Int -> IntAndColorParams 1) 
+                                   ptr xarr yarr len steps r g b a
+
+strokeThickLine : SDLRenderer -> IntAndColorParams 5
+strokeThickLine (MkRenderer ptr) x1 y1 x2 y2 width r g b a
+      = foreign FFI_C "thickLineRGBA"
+           (Ptr -> IntAndColorParams 5) ptr x1 y1 x2 y2 width r g b a

--- a/src/sdlrun2.c
+++ b/src/sdlrun2.c
@@ -160,55 +160,28 @@ void* rect(int x, int y, int w, int h) {
   return rect;
 }
 
-// -----------------------------------------------------------------------------
-// drawing - may not be needed after all...
-//
-void pixel(void *s_in,
-	   int x, int y,
-	   int r, int g, int b, int a) 
-{
-    SDL_Renderer* s = (SDL_Renderer*)s_in;
-    pixelRGBA(s, x, y, r, g, b, a);
-}
-
-void filledRect(void *s_in,
-	        int x, int y, int w, int h,
-	        int r, int g, int b, int a) 
-{
-    SDL_Renderer* s = (SDL_Renderer*)s_in;
-    boxRGBA(s, x, y, x+w, y+h, r, g, b, a);
-}
-
-void filledEllipse(void* s_in,
-		   int x, int y, int rx, int ry,
-                   int r, int g, int b, int a) 
-{
-    SDL_Renderer* s = (SDL_Renderer*)s_in;
-    filledEllipseRGBA(s, x, y, rx, ry, r, g, b, a);
-}
-
-void drawLine(void* s_in,
-	      int x, int y, int ex, int ey,
-	      int r, int g, int b, int a) 
-{
-    SDL_Renderer* s = (SDL_Renderer*)s_in;
-    lineRGBA(s, x, y, ex, ey, r, g, b, a);
-}
-
-
-void filledTrigon(void* s_in,
-		  int x1, int y1,
-		  int x2, int y2,
-		  int x3, int y3,
-		  int r, int g, int b, int a)
-{
-    SDL_Renderer* s = (SDL_Renderer*)s_in;
-    filledTrigonRGBA(s, x1, y1, x2, y2, x3, y3, r, g, b, a);
-}
 
 // --------------------------------------------------------------------
 // 
 //
+
+void strokePolygon(void* s_in, int* xs, int* ys, int n, int r, int g, int b, int a)
+{
+    SDL_Renderer* s = (SDL_Renderer*)s_in;
+    short u[n];
+    short v[n];
+    for (int i = 0; i < n ; i++) {
+      u[i] = xs[i];
+      v[i] = ys[i];
+    }
+    free(xs);
+    free(ys);
+    polygonRGBA(s,
+		      u, v,
+		      n,
+		      r, g, b, a);
+
+}
 
 void filledPolygon(void* s_in, int* xs, int* ys, int n, int r, int g, int b, int a)
 {
@@ -229,7 +202,7 @@ void filledPolygon(void* s_in, int* xs, int* ys, int n, int r, int g, int b, int
 
 }
 
-void polygonAA(void* s_in, int* xs, int* ys, int n, int r, int g, int b, int a)
+void strokeAAPolygon(void* s_in, int* xs, int* ys, int n, int r, int g, int b, int a)
 {
     SDL_Renderer* s = (SDL_Renderer*)s_in;
     short u[n];

--- a/src/sdlrun2.c
+++ b/src/sdlrun2.c
@@ -297,7 +297,7 @@ VAL idr_lock_texture(SDL_Texture* texture, VM* vm) {
   int pitch;
   SDL_LockTexture(texture, NULL, &pixels, &pitch);  
 
-  idris_requireAlloc(128); // Conservative!
+  idris_requireAlloc(vm, 128); // Conservative!
 
   idris_constructor(m, vm, 0, 0, 0);
   idris_setConArg(m, 0, MKPTR(vm, pixels));
@@ -466,7 +466,7 @@ void* processEvent(VM* vm, int r, SDL_Event * e) {
   VAL idris_event;
 
   SDL_Event event = *e;
-  idris_requireAlloc(128); // Conservative!
+  idris_requireAlloc(vm, 128); // Conservative!
 
 
   if (r==0) {

--- a/src/sdlrun2.h
+++ b/src/sdlrun2.h
@@ -40,36 +40,17 @@ void* waitEvent(VM* vm); // builds an Idris value
 void* color(int r, int g, int b, int a);
 void* rect(int x, int y, int w, int h);
 
-// Drawing primitives
-
-void pixel(void *s_in,
-	   int x, int y,
-	   int r, int g, int b, int a);
-
-void filledRect(void *s,
-	        int x, int y, int w, int h,
-	        int r, int g, int b, int a);
-
-void filledEllipse(void* s_in,
-		   int x, int y, int rx, int ry,
-                   int r, int g, int b, int a);
-void drawLine(void* s_in,
-	      int x, int y, int ex, int ey,
-	      int r, int g, int b, int a);
-
-void filledTrigon(void* s_in,
-		  int x1, int y1,
-		  int x2, int y2,
-		  int x3, int y3,
-		  int r, int g, int b, int a);
-
 // these are really needed
 
 void filledPolygon(void* s_in,
 		   int* xs, int* ys, int n,
 		   int r, int g, int b, int a);
 
-void polygonAA(void* s_in,
+void strokePolygon(void* s_in,
+		   int* xs, int* ys, int n,
+		   int r, int g, int b, int a);
+
+void strokeAAPolygon(void* s_in,
 	       int* xs, int* ys, int n,
 	       int r, int g, int b, int a);
 


### PR DESCRIPTION
The first commit is unrelated, and was necessary for me to get this to compile (Idris version 1.3.1).

This adds most of the remaining graphics primitives from SDL2_gfx, renames some existing ones for consistency (filled shapes are called "filled..." and unfilled ones are called "stroke...", except pixel, which isn't really stroked, keeps its name "sdlPixel"), and moves them all to a separate module, because the main module was getting rather long. The non-effects example is also updated so that it uses every single graphics primitive.