### PR TITLE
Update idris_requireAlloc call so it builds again.

### DIFF
--- a/src/sdlrun2.c
+++ b/src/sdlrun2.c
@@ -297,7 +297,7 @@ VAL idr_lock_texture(SDL_Texture* texture, VM* vm) {
   int pitch;
   SDL_LockTexture(texture, NULL, &pixels, &pitch);  
 
-  idris_requireAlloc(128); // Conservative!
+  idris_requireAlloc(vm, 128); // Conservative!
 
   idris_constructor(m, vm, 0, 0, 0);
   idris_setConArg(m, 0, MKPTR(vm, pixels));
@@ -466,7 +466,7 @@ void* processEvent(VM* vm, int r, SDL_Event * e) {
   VAL idris_event;
 
   SDL_Event event = *e;
-  idris_requireAlloc(128); // Conservative!
+  idris_requireAlloc(vm, 128); // Conservative!
 
 
   if (r==0) {


### PR DESCRIPTION
This function was changed to also take a `VM` pointer a couple years
ago:
https://github.com/idris-lang/Idris-dev/commit/4698b9ae4dccc9c33356bce5bab0b4736549a989#diff-6bd2c2c50acd6e5c738683f3e740f21dR356